### PR TITLE
feat: cleaning dangling docker image then logout

### DIFF
--- a/internal/docker/model.go
+++ b/internal/docker/model.go
@@ -51,6 +51,8 @@ func (m *Model) ParsePullCommand() string {
 		fmt.Sprintf("docker stop %s", m.Name),
 		"docker container prune -f",
 		fmt.Sprintf("docker run --name %s -d %s %s", m.Name, m.Args, m.Image),
+		`docker image prune --filter "dangling=true" -f`,
+		"docker logout",
 	}
 
 	return strings.Join(str, " && ")

--- a/internal/docker/model_test.go
+++ b/internal/docker/model_test.go
@@ -115,7 +115,9 @@ func TestModel_ParsePullCommand(t *testing.T) {
 				"docker pull -q nzk/private:latest && " +
 				"docker stop private_latest && " +
 				"docker container prune -f && " +
-				"docker run --name private_latest -d  nzk/private:latest",
+				"docker run --name private_latest -d  nzk/private:latest && " +
+				`docker image prune --filter "dangling=true" -f && ` +
+				"docker logout",
 		},
 		{
 			name:   "Should result as expected with minimal required fields are provided and args also provided",
@@ -124,7 +126,9 @@ func TestModel_ParsePullCommand(t *testing.T) {
 				"docker pull -q nzk/private:latest && " +
 				"docker stop private_latest && " +
 				"docker container prune -f && " +
-				"docker run --name private_latest -d -p 1000:1000 nzk/private:latest",
+				"docker run --name private_latest -d -p 1000:1000 nzk/private:latest && " +
+				`docker image prune --filter "dangling=true" -f && ` +
+				"docker logout",
 		},
 	}
 


### PR DESCRIPTION
every CD job executed there is always left over images that has <none> tag and of course no longer used so its a must to clean that up after do `run` new container with the latest image and also need to logout and remove credential from `.docker/config.json`